### PR TITLE
Phase 2: Add static site generator (cmd/generate)

### DIFF
--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -230,16 +231,16 @@ func TestRSSIsValidXML(t *testing.T) {
 
 	// Verify it contains expected RSS elements
 	rssContent := string(data)
-	if !contains(rssContent, "<rss") {
+	if !strings.Contains(rssContent, "<rss") {
 		t.Error("RSS missing <rss> element")
 	}
-	if !contains(rssContent, "<channel>") {
+	if !strings.Contains(rssContent, "<channel>") {
 		t.Error("RSS missing <channel> element")
 	}
-	if !contains(rssContent, "<item>") {
+	if !strings.Contains(rssContent, "<item>") {
 		t.Error("RSS missing <item> elements")
 	}
-	if !contains(rssContent, "Tugberk Ugurlu") {
+	if !strings.Contains(rssContent, "Tugberk Ugurlu") {
 		t.Error("RSS missing author name")
 	}
 }
@@ -292,10 +293,10 @@ func Test404PageGenerated(t *testing.T) {
 	}
 
 	content := string(data)
-	if !contains(content, "Page Not Found") {
+	if !strings.Contains(content, "Page Not Found") {
 		t.Error("404.html missing 'Page Not Found' text")
 	}
-	if !contains(content, "<html") {
+	if !strings.Contains(content, "<html") {
 		t.Error("404.html missing HTML structure")
 	}
 }
@@ -332,15 +333,3 @@ func TestGeneratedHTMLNotEmpty(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// testFixtureDir returns the path to the shared testdata directory.
+func testFixtureDir() string {
+	return filepath.Join("..", "..", "internal", "blog", "testdata")
+}
+
+// setupTestTemplates creates minimal template files for testing.
+// These templates define the required "layout", "twitter_card", and "content"
+// blocks to match the real template structure.
+func setupTestTemplates(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// layout.html
+	layoutContent := `{{define "layout"}}<!doctype html><html><head><title>{{ .Title }}</title></head><body>{{template "twitter_card" .Data}}{{template "content" .Data}}</body></html>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "layout.html"), layoutContent)
+
+	// home.html
+	homeContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="home">{{ range $post := .Data.Posts }}<div>{{ $post.Metadata.Title }}</div>{{ end }}</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "home.html"), homeContent)
+
+	// blog.html (archive)
+	blogContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="archive">{{ range $post := .Data.Posts }}<div>{{ $post.Metadata.Title }}</div>{{ end }}</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "blog.html"), blogContent)
+
+	// post.html
+	postContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="post"><h1>{{ .Data.Post.Metadata.Title }}</h1><div>{{ .Data.Post.Body }}</div></div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "post.html"), postContent)
+
+	// tag.html
+	tagContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="tag"><h1>{{ .Data.Tag.Name }}</h1>{{ range $post := .Data.Posts }}<div>{{ $post.Metadata.Title }}</div>{{ end }}</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "tag.html"), tagContent)
+
+	// about.html
+	aboutContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="about">About page</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "about.html"), aboutContent)
+
+	// speaking.html
+	speakingContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="speaking">Speaking page</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "speaking.html"), speakingContent)
+
+	// contact.html
+	contactContent := `{{define "twitter_card"}}{{end}}{{define "content"}}<div id="contact">Contact page</div>{{end}}`
+	writeTestFile(t, filepath.Join(dir, "contact.html"), contactContent)
+
+	// shared/carousel.html (empty define, referenced but not needed in minimal templates)
+	os.MkdirAll(filepath.Join(dir, "shared"), 0755)
+	writeTestFile(t, filepath.Join(dir, "shared", "carousel.html"), `{{define "carousel"}}{{end}}`)
+	writeTestFile(t, filepath.Join(dir, "shared", "post-item.html"), `{{define "post-item"}}{{end}}`)
+	writeTestFile(t, filepath.Join(dir, "shared", "speaking-activity-card.html"), `{{define "speaking_activity_card"}}{{end}}`)
+
+	return dir
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupTestStaticDirs creates minimal static asset and static-root directories.
+func setupTestStaticDirs(t *testing.T) (string, string) {
+	t.Helper()
+	staticDir := t.TempDir()
+	staticRootDir := t.TempDir()
+
+	// Create a sample static asset
+	os.MkdirAll(filepath.Join(staticDir, "stylesheets"), 0755)
+	writeTestFile(t, filepath.Join(staticDir, "stylesheets", "main.css"), "body { margin: 0; }")
+
+	// Create static root files
+	writeTestFile(t, filepath.Join(staticRootDir, "robots.txt"), "User-agent: *\nAllow: /")
+	writeTestFile(t, filepath.Join(staticRootDir, "favicon.ico"), "fake-ico-data")
+
+	return staticDir, staticRootDir
+}
+
+func TestGenerateOutputStructure(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	// Verify expected files exist
+	expectedFiles := []string{
+		"index.html",
+		"archive/index.html",
+		"archive/first-test-post/index.html",
+		"archive/second-test-post/index.html",
+		"archive/third-test-post/index.html",
+		"archive/fourth-test-post-no-images/index.html",
+		"tags/go/index.html",
+		"tags/software-engineering/index.html",
+		"tags/architecture/index.html",
+		"tags/c-sharp/index.html",
+		"tags/cpp/index.html",
+		"about/index.html",
+		"speaking/index.html",
+		"contact/index.html",
+		"feeds/rss",
+		"404.html",
+		"_manifest.json",
+		"assets/stylesheets/main.css",
+		"robots.txt",
+		"favicon.ico",
+	}
+
+	for _, expected := range expectedFiles {
+		path := filepath.Join(outputDir, expected)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s does not exist", expected)
+		}
+	}
+}
+
+func TestManifestIsComplete(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	manifestPath := filepath.Join(outputDir, "_manifest.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parsing manifest: %v", err)
+	}
+
+	// 4 posts + archive + home + about + speaking + contact + 5 tags + RSS = 15 pages
+	// Tags: go, software-engineering, architecture, c-sharp, cpp
+	expectedPageCount := 15
+	if len(manifest.Pages) != expectedPageCount {
+		t.Errorf("expected %d pages in manifest, got %d", expectedPageCount, len(manifest.Pages))
+		for _, p := range manifest.Pages {
+			t.Logf("  page: %s -> %s", p.Path, p.File)
+		}
+	}
+
+	// post1 has "first-test-post-alias" as a second slug
+	expectedRedirectCount := 1
+	if len(manifest.Redirects) != expectedRedirectCount {
+		t.Errorf("expected %d redirects in manifest, got %d", expectedRedirectCount, len(manifest.Redirects))
+		for _, r := range manifest.Redirects {
+			t.Logf("  redirect: %s -> %s", r.From, r.To)
+		}
+	}
+
+	// Verify the redirect
+	if len(manifest.Redirects) > 0 {
+		r := manifest.Redirects[0]
+		if r.From != "/archive/first-test-post-alias" {
+			t.Errorf("expected redirect from /archive/first-test-post-alias, got %s", r.From)
+		}
+		if r.To != "/archive/first-test-post" {
+			t.Errorf("expected redirect to /archive/first-test-post, got %s", r.To)
+		}
+		if r.Status != 301 {
+			t.Errorf("expected redirect status 301, got %d", r.Status)
+		}
+	}
+
+	// Verify pattern
+	if len(manifest.Patterns) != 1 {
+		t.Errorf("expected 1 pattern in manifest, got %d", len(manifest.Patterns))
+	}
+	if len(manifest.Patterns) > 0 {
+		p := manifest.Patterns[0]
+		if p.Pattern != "/content/images/*" {
+			t.Errorf("expected pattern /content/images/*, got %s", p.Pattern)
+		}
+	}
+
+	// Verify all pages have non-empty content hashes
+	for _, page := range manifest.Pages {
+		if page.ContentHash == "" {
+			t.Errorf("page %s has empty content hash", page.Path)
+		}
+		if page.File == "" {
+			t.Errorf("page %s has empty file path", page.Path)
+		}
+	}
+}
+
+func TestRSSIsValidXML(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	rssPath := filepath.Join(outputDir, "feeds", "rss")
+	data, err := os.ReadFile(rssPath)
+	if err != nil {
+		t.Fatalf("reading RSS: %v", err)
+	}
+
+	// Verify it is valid XML
+	var xmlDoc interface{}
+	if err := xml.Unmarshal(data, &xmlDoc); err != nil {
+		t.Fatalf("RSS is not valid XML: %v", err)
+	}
+
+	// Verify it contains expected RSS elements
+	rssContent := string(data)
+	if !contains(rssContent, "<rss") {
+		t.Error("RSS missing <rss> element")
+	}
+	if !contains(rssContent, "<channel>") {
+		t.Error("RSS missing <channel> element")
+	}
+	if !contains(rssContent, "<item>") {
+		t.Error("RSS missing <item> elements")
+	}
+	if !contains(rssContent, "Tugberk Ugurlu") {
+		t.Error("RSS missing author name")
+	}
+}
+
+func TestStaticAssetsCopied(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	// Check static assets
+	cssPath := filepath.Join(outputDir, "assets", "stylesheets", "main.css")
+	cssData, err := os.ReadFile(cssPath)
+	if err != nil {
+		t.Fatalf("reading copied CSS: %v", err)
+	}
+	if string(cssData) != "body { margin: 0; }" {
+		t.Error("copied CSS content does not match source")
+	}
+
+	// Check static root files
+	robotsPath := filepath.Join(outputDir, "robots.txt")
+	robotsData, err := os.ReadFile(robotsPath)
+	if err != nil {
+		t.Fatalf("reading copied robots.txt: %v", err)
+	}
+	if string(robotsData) != "User-agent: *\nAllow: /" {
+		t.Error("copied robots.txt content does not match source")
+	}
+}
+
+func Test404PageGenerated(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	path404 := filepath.Join(outputDir, "404.html")
+	data, err := os.ReadFile(path404)
+	if err != nil {
+		t.Fatalf("reading 404.html: %v", err)
+	}
+
+	content := string(data)
+	if !contains(content, "Page Not Found") {
+		t.Error("404.html missing 'Page Not Found' text")
+	}
+	if !contains(content, "<html") {
+		t.Error("404.html missing HTML structure")
+	}
+}
+
+func TestGeneratedHTMLNotEmpty(t *testing.T) {
+	templatesDir := setupTestTemplates(t)
+	staticDir, staticRootDir := setupTestStaticDirs(t)
+	outputDir := t.TempDir()
+
+	err := run(testFixtureDir(), templatesDir, staticDir, staticRootDir, testFixtureDir(), outputDir)
+	if err != nil {
+		t.Fatalf("run() failed: %v", err)
+	}
+
+	filesToCheck := []string{
+		"index.html",
+		"archive/index.html",
+		"archive/first-test-post/index.html",
+		"about/index.html",
+		"speaking/index.html",
+		"contact/index.html",
+	}
+
+	for _, file := range filesToCheck {
+		path := filepath.Join(outputDir, file)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("%s: stat error: %v", file, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s: file is empty", file)
+		}
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -1,0 +1,479 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gorilla/feeds"
+	"github.com/tugberkugurlu/go-bloggy/internal/blog"
+)
+
+// ManifestPage represents a generated page in the manifest.
+type ManifestPage struct {
+	Path        string `json:"path"`
+	File        string `json:"file"`
+	ContentHash string `json:"content_hash"`
+}
+
+// ManifestRedirect represents a slug redirect in the manifest.
+type ManifestRedirect struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Status int    `json:"status"`
+}
+
+// ManifestPattern represents a URL pattern redirect in the manifest.
+type ManifestPattern struct {
+	Pattern        string `json:"pattern"`
+	RedirectPrefix string `json:"redirect_prefix"`
+	Status         int    `json:"status"`
+}
+
+// Manifest is the build artifact listing all pages and redirects.
+type Manifest struct {
+	Pages     []ManifestPage     `json:"pages"`
+	Redirects []ManifestRedirect `json:"redirects"`
+	Patterns  []ManifestPattern  `json:"patterns"`
+}
+
+func main() {
+	postsDir := flag.String("posts", "./web/posts", "Path to blog posts directory")
+	templatesDir := flag.String("templates", "./web/template", "Path to templates directory")
+	staticDir := flag.String("static", "./web/static", "Path to static assets directory")
+	staticRootDir := flag.String("static-root", "./web/static-root", "Path to static root files directory")
+	configPath := flag.String("config", ".", "Path to directory containing config.yaml")
+	outputDir := flag.String("output", "./output", "Path to output directory")
+	flag.Parse()
+
+	if err := run(*postsDir, *templatesDir, *staticDir, *staticRootDir, *configPath, *outputDir); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(postsDir, templatesDir, staticDir, staticRootDir, configPath, outputDir string) error {
+	site, err := blog.LoadSite(blog.LoadSiteConfig{
+		PostsDir:   postsDir,
+		ConfigPath: configPath,
+	})
+	if err != nil {
+		return fmt.Errorf("loading site: %w", err)
+	}
+
+	site.LayoutConfig = blog.LayoutConfig{
+		AssetsUrl: site.Config.FullAssetsUrl(),
+	}
+
+	if err := os.RemoveAll(outputDir); err != nil {
+		return fmt.Errorf("cleaning output directory: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	g := &generator{
+		site:         site,
+		templatesDir: templatesDir,
+		outputDir:    outputDir,
+	}
+
+	// Generate all pages
+	log.Println("Generating home page...")
+	if err := g.generateHome(); err != nil {
+		return fmt.Errorf("generating home: %w", err)
+	}
+
+	log.Println("Generating archive page...")
+	if err := g.generateArchive(); err != nil {
+		return fmt.Errorf("generating archive: %w", err)
+	}
+
+	log.Printf("Generating %d post pages...\n", len(site.Posts))
+	if err := g.generatePosts(); err != nil {
+		return fmt.Errorf("generating posts: %w", err)
+	}
+
+	log.Printf("Generating %d tag pages...\n", len(site.TagsBySlug))
+	if err := g.generateTags(); err != nil {
+		return fmt.Errorf("generating tags: %w", err)
+	}
+
+	log.Println("Generating about page...")
+	if err := g.generateAbout(); err != nil {
+		return fmt.Errorf("generating about: %w", err)
+	}
+
+	log.Println("Generating speaking page...")
+	if err := g.generateSpeaking(); err != nil {
+		return fmt.Errorf("generating speaking: %w", err)
+	}
+
+	log.Println("Generating contact page...")
+	if err := g.generateContact(); err != nil {
+		return fmt.Errorf("generating contact: %w", err)
+	}
+
+	log.Println("Generating RSS feed...")
+	if err := g.generateRSS(); err != nil {
+		return fmt.Errorf("generating RSS: %w", err)
+	}
+
+	log.Println("Generating 404 page...")
+	if err := g.generate404(); err != nil {
+		return fmt.Errorf("generating 404: %w", err)
+	}
+
+	// Copy static assets
+	log.Println("Copying static assets...")
+	if err := copyDir(staticDir, filepath.Join(outputDir, "assets")); err != nil {
+		return fmt.Errorf("copying static assets: %w", err)
+	}
+
+	// Copy static root files
+	log.Println("Copying static root files...")
+	if err := copyDir(staticRootDir, outputDir); err != nil {
+		return fmt.Errorf("copying static root files: %w", err)
+	}
+
+	// Build and write manifest
+	log.Println("Writing manifest...")
+	if err := g.writeManifest(); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+
+	log.Printf("Generation complete: %d pages, %d redirects\n", len(g.manifest.Pages), len(g.manifest.Redirects))
+	return nil
+}
+
+type generator struct {
+	site         *blog.Site
+	templatesDir string
+	outputDir    string
+	manifest     Manifest
+}
+
+func (g *generator) templatePath(name string) string {
+	return filepath.Join(g.templatesDir, name)
+}
+
+func (g *generator) renderAndWrite(urlPath, filePath string, templatePaths []string, section string, data interface{}) error {
+	absFilePath := filepath.Join(g.outputDir, filePath)
+	if err := os.MkdirAll(filepath.Dir(absFilePath), 0755); err != nil {
+		return fmt.Errorf("creating directory for %s: %w", filePath, err)
+	}
+
+	f, err := os.Create(absFilePath)
+	if err != nil {
+		return fmt.Errorf("creating file %s: %w", filePath, err)
+	}
+	defer f.Close()
+
+	layoutPath := g.templatePath("layout.html")
+	if err := blog.RenderPage(f, g.site.LayoutConfig, templatePaths, layoutPath, section, g.site.TagsList, data); err != nil {
+		return fmt.Errorf("rendering %s: %w", urlPath, err)
+	}
+
+	// Compute content hash
+	if _, err := f.Seek(0, 0); err != nil {
+		return fmt.Errorf("seeking %s: %w", filePath, err)
+	}
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return fmt.Errorf("hashing %s: %w", filePath, err)
+	}
+	contentHash := hex.EncodeToString(hash.Sum(nil))[:16]
+
+	g.manifest.Pages = append(g.manifest.Pages, ManifestPage{
+		Path:        urlPath,
+		File:        filePath,
+		ContentHash: contentHash,
+	})
+
+	return nil
+}
+
+func (g *generator) generateHome() error {
+	data := blog.Home{
+		TopCarousel:        g.site.Carousels[0],
+		Posts:              g.site.Posts[:min(3, len(g.site.Posts))],
+		SpeakingActivities: g.site.Speaking[:min(4, len(g.site.Speaking))],
+	}
+	return g.renderAndWrite("/", "index.html", []string{
+		g.templatePath("home.html"),
+		g.templatePath("shared/carousel.html"),
+		g.templatePath("shared/post-item.html"),
+		g.templatePath("shared/speaking-activity-card.html"),
+	}, "", data)
+}
+
+func (g *generator) generateArchive() error {
+	data := blog.Blog{
+		Posts: g.site.Posts,
+	}
+	return g.renderAndWrite("/archive", "archive/index.html", []string{
+		g.templatePath("blog.html"),
+		g.templatePath("shared/post-item.html"),
+	}, "archive", data)
+}
+
+func (g *generator) generatePosts() error {
+	for _, post := range g.site.Posts {
+		canonicalSlug := post.Metadata.Slugs[0]
+		urlPath := fmt.Sprintf("/archive/%s", canonicalSlug)
+		filePath := fmt.Sprintf("archive/%s/index.html", canonicalSlug)
+
+		data := blog.PostPage{
+			Post:                 post,
+			RelatedPostsCarousel: blog.GetRelatedPostsCarousel(post, g.site.PostsByTagSlug),
+			AdTags:               strings.Join(post.Metadata.Tags, ","),
+		}
+		if err := g.renderAndWrite(urlPath, filePath, []string{
+			g.templatePath("post.html"),
+			g.templatePath("shared/carousel.html"),
+		}, "archive", data); err != nil {
+			return err
+		}
+
+		// Register non-canonical slug redirects
+		for _, slug := range post.Metadata.Slugs[1:] {
+			g.manifest.Redirects = append(g.manifest.Redirects, ManifestRedirect{
+				From:   fmt.Sprintf("/archive/%s", slug),
+				To:     urlPath,
+				Status: 301,
+			})
+		}
+	}
+	return nil
+}
+
+func (g *generator) generateTags() error {
+	for tagSlug, tag := range g.site.TagsBySlug {
+		posts := g.site.PostsByTagSlug[tagSlug]
+		urlPath := fmt.Sprintf("/tags/%s", tagSlug)
+		filePath := fmt.Sprintf("tags/%s/index.html", tagSlug)
+
+		data := blog.TagsPage{
+			Posts: posts,
+			Tag:   tag,
+		}
+		if err := g.renderAndWrite(urlPath, filePath, []string{
+			g.templatePath("tag.html"),
+			g.templatePath("shared/post-item.html"),
+		}, "tags", data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *generator) generateAbout() error {
+	data := blog.AboutPage{
+		GeekTalksCarousel: blog.GetCarouselForTag("geek-talks", "Posts on Speaking", g.site.PostsByTagSlug),
+		TopCarousel:       g.site.Carousels[0],
+	}
+	return g.renderAndWrite("/about", "about/index.html", []string{
+		g.templatePath("about.html"),
+		g.templatePath("shared/carousel.html"),
+	}, "about", data)
+}
+
+func (g *generator) generateSpeaking() error {
+	data := blog.SpeakingPage{
+		GeekTalksCarousel:  blog.GetCarouselForTag("geek-talks", "Posts on Speaking", g.site.PostsByTagSlug),
+		SpeakingActivities: g.site.Speaking,
+	}
+	return g.renderAndWrite("/speaking", "speaking/index.html", []string{
+		g.templatePath("speaking.html"),
+		g.templatePath("shared/speaking-activity-card.html"),
+		g.templatePath("shared/carousel.html"),
+	}, "speaking", data)
+}
+
+func (g *generator) generateContact() error {
+	data := blog.ContactPage{
+		ArchitectureCarousel: blog.GetCarouselForTag("architecture", "Top Picks for Architecture", g.site.PostsByTagSlug),
+	}
+	return g.renderAndWrite("/contact", "contact/index.html", []string{
+		g.templatePath("contact.html"),
+		g.templatePath("shared/carousel.html"),
+	}, "contact", data)
+}
+
+func (g *generator) generateRSS() error {
+	author := &feeds.Author{Name: "Tugberk Ugurlu"}
+	feed := &feeds.Feed{
+		Title:       "Tugberk Ugurlu @ the Heart of Software",
+		Link:        &feeds.Link{Href: "https://www.tugberkugurlu.com"},
+		Description: "Software Engineer and Tech Product enthusiast Tugberk Ugurlu's home on the interwebs! Here, you can find out about Tugberk's conference talks, books and blog posts on software development techniques and practices",
+		Author:      author,
+	}
+
+	count := min(20, len(g.site.Posts))
+	for _, post := range g.site.Posts[:count] {
+		postLink := blog.GeneratePostURL(post)
+		feed.Items = append(feed.Items, &feeds.Item{
+			Title:       post.Metadata.Title,
+			Description: string(post.Body),
+			Created:     post.PublishedOn,
+			Author:      author,
+			Link:        &feeds.Link{Href: postLink},
+			Id:          postLink,
+		})
+	}
+
+	rss, err := feed.ToRss()
+	if err != nil {
+		return fmt.Errorf("generating RSS XML: %w", err)
+	}
+
+	rssPath := filepath.Join(g.outputDir, "feeds", "rss")
+	if err := os.MkdirAll(filepath.Dir(rssPath), 0755); err != nil {
+		return fmt.Errorf("creating feeds directory: %w", err)
+	}
+	if err := os.WriteFile(rssPath, []byte(rss), 0644); err != nil {
+		return fmt.Errorf("writing RSS file: %w", err)
+	}
+
+	// Add RSS to manifest
+	hash := sha256.Sum256([]byte(rss))
+	g.manifest.Pages = append(g.manifest.Pages, ManifestPage{
+		Path:        "/feeds/rss",
+		File:        "feeds/rss",
+		ContentHash: hex.EncodeToString(hash[:])[:16],
+	})
+
+	return nil
+}
+
+func (g *generator) generate404() error {
+	// The 404 page uses the layout template with a simple error message.
+	// We create a minimal "not found" content template inline is not practical,
+	// so we render it directly by writing the file.
+	absFilePath := filepath.Join(g.outputDir, "404.html")
+
+	f, err := os.Create(absFilePath)
+	if err != nil {
+		return fmt.Errorf("creating 404.html: %w", err)
+	}
+	defer f.Close()
+
+	// Use the home template structure but render a 404 page.
+	// We need a template that defines "twitter_card" and "content" blocks.
+	// Since there is no dedicated 404 template, we create the HTML directly
+	// using RenderPage with a custom template.
+	err = g.renderNotFoundPage(f)
+	if err != nil {
+		return fmt.Errorf("rendering 404 page: %w", err)
+	}
+
+	return nil
+}
+
+func (g *generator) renderNotFoundPage(w io.Writer) error {
+	// Write a 404 template file temporarily
+	notFoundTemplate := `{{define "twitter_card"}}{{end}}
+{{define "content"}}
+<div class="ui container" style="padding: 40px 0; text-align: center;">
+    <h1 class="ui header">
+        <i class="frown outline icon"></i>
+        Page Not Found
+    </h1>
+    <p>Sorry, the page you are looking for does not exist.</p>
+    <a class="ui purple button" href="/">Go to Home Page</a>
+</div>
+{{end}}`
+
+	tmpFile, err := os.CreateTemp("", "404-template-*.html")
+	if err != nil {
+		return fmt.Errorf("creating temp 404 template: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	if _, err := tmpFile.WriteString(notFoundTemplate); err != nil {
+		return fmt.Errorf("writing temp 404 template: %w", err)
+	}
+	tmpFile.Close()
+
+	layoutPath := g.templatePath("layout.html")
+	return blog.RenderPage(w, g.site.LayoutConfig, []string{tmpFile.Name()}, layoutPath, "", g.site.TagsList, nil)
+}
+
+func (g *generator) writeManifest() error {
+	// Add legacy image redirect pattern
+	g.manifest.Patterns = append(g.manifest.Patterns, ManifestPattern{
+		Pattern:        "/content/images/*",
+		RedirectPrefix: "https://tugberkugurlu.blob.core.windows.net/bloggyimages/legacy-blog-images/images",
+		Status:         301,
+	})
+
+	data, err := json.MarshalIndent(g.manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling manifest: %w", err)
+	}
+
+	manifestPath := filepath.Join(g.outputDir, "_manifest.json")
+	if err := os.WriteFile(manifestPath, data, 0644); err != nil {
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+
+	return nil
+}
+
+// copyDir recursively copies a directory tree from src to dst.
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, 0755)
+		}
+
+		return copyFile(path, dstPath)
+	})
+}
+
+// copyFile copies a single file from src to dst.
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	return err
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -353,9 +353,6 @@ func (g *generator) generateRSS() error {
 }
 
 func (g *generator) generate404() error {
-	// The 404 page uses the layout template with a simple error message.
-	// We create a minimal "not found" content template inline is not practical,
-	// so we render it directly by writing the file.
 	absFilePath := filepath.Join(g.outputDir, "404.html")
 
 	f, err := os.Create(absFilePath)
@@ -364,12 +361,10 @@ func (g *generator) generate404() error {
 	}
 	defer f.Close()
 
-	// Use the home template structure but render a 404 page.
-	// We need a template that defines "twitter_card" and "content" blocks.
-	// Since there is no dedicated 404 template, we create the HTML directly
-	// using RenderPage with a custom template.
-	err = g.renderNotFoundPage(f)
-	if err != nil {
+	// There is no dedicated 404 template in the blog, so we create a
+	// temporary template that defines the required "twitter_card" and
+	// "content" blocks, then render it through the standard layout.
+	if err := g.renderNotFoundPage(f); err != nil {
 		return fmt.Errorf("rendering 404 page: %w", err)
 	}
 
@@ -471,9 +466,3 @@ func copyFile(src, dst string) error {
 	return err
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
## Summary

- Add `cmd/generate`, a standalone CLI that generates a complete static site from the blog content
- Uses `internal/blog` package (from Phase 1) to load posts, render pages via shared templates, generate RSS feed, and emit a build manifest
- Generates all page types: home, archive, 219 individual posts, 132 tag pages, about, speaking, contact, RSS feed, and 404.html
- Copies static assets from `web/static/` and `web/static-root/` to output directory
- Emits `_manifest.json` with all pages (357), redirects (22 non-canonical slugs), and legacy image redirect patterns
- Includes tests validating output structure, manifest completeness, RSS validity, static asset copying, and 404 page generation

## Usage

```
go run ./cmd/generate \
  -posts ./web/posts \
  -templates ./web/template \
  -static ./web/static \
  -static-root ./web/static-root \
  -config . \
  -output ./output
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (6 new tests in cmd/generate)
- [x] `go vet ./...` passes
- [x] Generator produces correct output for all 219 posts
- [x] All 132 tag pages generated
- [x] RSS feed is valid XML with 20 items
- [x] `_manifest.json` is complete (357 pages + 22 redirects + 1 pattern)
- [x] Static assets copied correctly (semantic-ui, stylesheets, images)
- [x] Static root files copied (robots.txt, favicon.ico)
- [x] 404.html generated with layout styling

Co-Authored-By: Claude <noreply@anthropic.com>