### PR TITLE
Phase 3: Add side-by-side comparison and E2E tests

### DIFF
--- a/internal/blog/types.go
+++ b/internal/blog/types.go
@@ -78,7 +78,13 @@ type TagCountPair struct {
 type TagCountPairList []TagCountPair
 
 func (p TagCountPairList) Len() int           { return len(p) }
-func (p TagCountPairList) Less(i, j int) bool { return p[i].Value.Count < p[j].Value.Count }
+func (p TagCountPairList) Less(i, j int) bool {
+	if p[i].Value.Count != p[j].Value.Count {
+		return p[i].Value.Count < p[j].Value.Count
+	}
+	// Tiebreaker: alphabetical by slug key for deterministic ordering
+	return p[i].Key < p[j].Key
+}
 func (p TagCountPairList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // Carousel holds a titled collection of posts for carousel display.

--- a/test/comparison/comparison_test.go
+++ b/test/comparison/comparison_test.go
@@ -1,0 +1,286 @@
+package comparison
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// manifestPage represents a page entry in _manifest.json.
+type manifestPage struct {
+	Path        string `json:"path"`
+	File        string `json:"file"`
+	ContentHash string `json:"content_hash"`
+}
+
+// manifestRedirect represents a redirect entry in _manifest.json.
+type manifestRedirect struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Status int    `json:"status"`
+}
+
+// manifest represents the full _manifest.json structure.
+type manifest struct {
+	Pages     []manifestPage     `json:"pages"`
+	Redirects []manifestRedirect `json:"redirects"`
+}
+
+// repoRoot returns the repository root relative to this test file.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// test/comparison/ -> repo root is ../..
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	return root
+}
+
+// getFreePort finds a free TCP port on localhost that fits in int16 range
+// (required by cmd/web which parses SERVER_PORT with ParseInt base 10 size 16).
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	// Try ports in the safe range (9000-32000)
+	for port := 9847; port < 32000; port++ {
+		listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+		if err == nil {
+			listener.Close()
+			return port
+		}
+	}
+	t.Fatal("could not find a free port in the int16 range")
+	return 0
+}
+
+// generateStaticSite runs cmd/generate and returns the output directory.
+func generateStaticSite(t *testing.T, root string) string {
+	t.Helper()
+	outputDir := t.TempDir()
+
+	cmd := exec.Command("go", "run", "./cmd/generate",
+		"-posts", filepath.Join(root, "web", "posts"),
+		"-templates", filepath.Join(root, "web", "template"),
+		"-static", filepath.Join(root, "web", "static"),
+		"-static-root", filepath.Join(root, "web", "static-root"),
+		"-config", root,
+		"-output", outputDir,
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running generator: %v\n%s", err, out)
+	}
+	return outputDir
+}
+
+// startWebServer starts cmd/web on the given port and returns a cleanup function.
+func startWebServer(t *testing.T, root string, port int) func() {
+	t.Helper()
+
+	// cmd/web uses relative paths (../../web/posts, ../../web/template, etc.)
+	// so it must be run from within cmd/web/ directory using "go run ."
+	cmd := exec.Command("go", "run", ".")
+	cmd.Dir = filepath.Join(root, "cmd", "web")
+	// Build env with SERVER_PORT override. Filter out any existing SERVER_PORT.
+	env := os.Environ()
+	filteredEnv := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "SERVER_PORT=") {
+			filteredEnv = append(filteredEnv, e)
+		}
+	}
+	filteredEnv = append(filteredEnv, fmt.Sprintf("SERVER_PORT=%d", port))
+	cmd.Env = filteredEnv
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting web server: %v", err)
+	}
+
+	// Wait for the server to be ready
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL)
+		if err == nil {
+			resp.Body.Close()
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Verify server is up
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		cmd.Process.Kill()
+		t.Fatalf("web server did not start within timeout: %v", err)
+	}
+	resp.Body.Close()
+
+	return func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}
+}
+
+// normalizeHTML removes leading/trailing whitespace from each line and collapses
+// multiple consecutive blank lines. This handles minor whitespace differences
+// between the Go server response and the static file.
+func normalizeHTML(s string) string {
+	lines := strings.Split(s, "\n")
+	var result []string
+	prevBlank := false
+	for _, line := range lines {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if trimmed == "" {
+			if prevBlank {
+				continue
+			}
+			prevBlank = true
+		} else {
+			prevBlank = false
+		}
+		result = append(result, trimmed)
+	}
+	return strings.TrimSpace(strings.Join(result, "\n"))
+}
+
+func TestSideBySideComparison(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping side-by-side comparison test in short mode")
+	}
+
+	root := repoRoot(t)
+
+	// Step 1: Generate static site
+	t.Log("Generating static site...")
+	outputDir := generateStaticSite(t, root)
+
+	// Step 2: Start web server
+	port := getFreePort(t)
+	t.Logf("Starting web server on port %d...", port)
+	cleanup := startWebServer(t, root, port)
+	defer cleanup()
+
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+
+	// Step 3: Load manifest
+	manifestData, err := os.ReadFile(filepath.Join(outputDir, "_manifest.json"))
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var m manifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		t.Fatalf("parsing manifest: %v", err)
+	}
+
+	t.Logf("Comparing %d pages and %d redirects...", len(m.Pages), len(m.Redirects))
+
+	// Step 4: Compare each HTML page
+	client := &http.Client{
+		// Do not follow redirects
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	mismatches := 0
+	for _, page := range m.Pages {
+		// Skip RSS feed -- it has a dynamic timestamp from gorilla/feeds
+		if page.Path == "/feeds/rss" {
+			continue
+		}
+
+		// Read static file
+		staticFilePath := filepath.Join(outputDir, page.File)
+		staticData, err := os.ReadFile(staticFilePath)
+		if err != nil {
+			t.Errorf("reading static file %s: %v", page.File, err)
+			continue
+		}
+
+		// Fetch from web server
+		resp, err := client.Get(baseURL + page.Path)
+		if err != nil {
+			t.Errorf("fetching %s: %v", page.Path, err)
+			continue
+		}
+		serverData, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			t.Errorf("reading response for %s: %v", page.Path, err)
+			continue
+		}
+
+		if resp.StatusCode != 200 {
+			t.Errorf("page %s: expected status 200, got %d", page.Path, resp.StatusCode)
+			continue
+		}
+
+		// Compare normalized HTML
+		staticNorm := normalizeHTML(string(staticData))
+		serverNorm := normalizeHTML(string(serverData))
+
+		if staticNorm != serverNorm {
+			mismatches++
+			// Show first difference for debugging
+			staticLines := strings.Split(staticNorm, "\n")
+			serverLines := strings.Split(serverNorm, "\n")
+			for i := 0; i < len(staticLines) && i < len(serverLines); i++ {
+				if staticLines[i] != serverLines[i] {
+					t.Errorf("page %s: first difference at line %d:\n  static: %q\n  server: %q",
+						page.Path, i+1, staticLines[i], serverLines[i])
+					break
+				}
+			}
+			if len(staticLines) != len(serverLines) {
+				t.Errorf("page %s: different line count: static=%d server=%d",
+					page.Path, len(staticLines), len(serverLines))
+			}
+			if mismatches >= 5 {
+				t.Fatalf("too many mismatches (%d), stopping comparison", mismatches)
+			}
+		}
+	}
+
+	if mismatches == 0 {
+		t.Logf("All %d pages match!", len(m.Pages)-1) // -1 for skipped RSS
+	}
+
+	// Step 5: Verify redirects
+	for _, redirect := range m.Redirects {
+		resp, err := client.Get(baseURL + redirect.From)
+		if err != nil {
+			t.Errorf("fetching redirect %s: %v", redirect.From, err)
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != redirect.Status {
+			t.Errorf("redirect %s: expected status %d, got %d",
+				redirect.From, redirect.Status, resp.StatusCode)
+		}
+
+		location := resp.Header.Get("Location")
+		// The Go server redirects to the full URL, while the manifest has the path.
+		// Check that the location ends with the expected path.
+		expectedSuffix := redirect.To
+		if !strings.HasSuffix(location, expectedSuffix) {
+			// The server might use the full URL form
+			expectedFull := fmt.Sprintf("https://www.tugberkugurlu.com%s", redirect.To)
+			if location != expectedFull {
+				t.Errorf("redirect %s: expected Location ending with %q or %q, got %q",
+					redirect.From, expectedSuffix, expectedFull, location)
+			}
+		}
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,389 @@
+package e2e
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// manifestPage represents a page entry in _manifest.json.
+type manifestPage struct {
+	Path        string `json:"path"`
+	File        string `json:"file"`
+	ContentHash string `json:"content_hash"`
+}
+
+// manifest represents the _manifest.json structure.
+type manifest struct {
+	Pages []manifestPage `json:"pages"`
+}
+
+// rss represents the top-level RSS XML structure for parsing.
+type rss struct {
+	XMLName xml.Name   `xml:"rss"`
+	Channel rssChannel `xml:"channel"`
+}
+
+type rssChannel struct {
+	Items []rssItem `xml:"item"`
+}
+
+type rssItem struct {
+	Link string `xml:"link"`
+}
+
+// repoRoot returns the repository root relative to this test file.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	return root
+}
+
+// generateStaticSite runs cmd/generate and returns the output directory.
+func generateStaticSite(t *testing.T, root string) string {
+	t.Helper()
+	outputDir := t.TempDir()
+
+	cmd := exec.Command("go", "run", "./cmd/generate",
+		"-posts", filepath.Join(root, "web", "posts"),
+		"-templates", filepath.Join(root, "web", "template"),
+		"-static", filepath.Join(root, "web", "static"),
+		"-static-root", filepath.Join(root, "web", "static-root"),
+		"-config", root,
+		"-output", outputDir,
+	)
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running generator: %v\n%s", err, out)
+	}
+	return outputDir
+}
+
+// fileExistsInOutput checks if a given URL path resolves to a file in the
+// output directory. It handles both directory-style paths (path/index.html)
+// and direct files (path).
+func fileExistsInOutput(outputDir, urlPath string) bool {
+	// Remove leading /
+	cleanPath := strings.TrimPrefix(urlPath, "/")
+	if cleanPath == "" {
+		cleanPath = "index.html"
+	}
+
+	// Try direct path
+	direct := filepath.Join(outputDir, cleanPath)
+	if _, err := os.Stat(direct); err == nil {
+		return true
+	}
+
+	// Try as directory with index.html
+	withIndex := filepath.Join(outputDir, cleanPath, "index.html")
+	if _, err := os.Stat(withIndex); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// extractLinksFromHTML parses HTML and extracts all href and src attributes
+// that point to internal paths (starting with /).
+func extractLinksFromHTML(htmlContent string) (hrefs []string, srcs []string) {
+	doc, err := html.Parse(strings.NewReader(htmlContent))
+	if err != nil {
+		return
+	}
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			for _, attr := range n.Attr {
+				val := attr.Val
+				// Only consider paths starting with / but not // (protocol-relative URLs)
+				isInternal := strings.HasPrefix(val, "/") && !strings.HasPrefix(val, "//")
+				if attr.Key == "href" && isInternal {
+					hrefs = append(hrefs, val)
+				}
+				if attr.Key == "src" && isInternal {
+					srcs = append(srcs, val)
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return
+}
+
+func TestLinkIntegrity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E link integrity test in short mode")
+	}
+
+	root := repoRoot(t)
+
+	t.Log("Generating static site...")
+	outputDir := generateStaticSite(t, root)
+
+	// Load manifest to know all page paths
+	manifestData, err := os.ReadFile(filepath.Join(outputDir, "_manifest.json"))
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var m manifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		t.Fatalf("parsing manifest: %v", err)
+	}
+
+	// Build set of known paths from manifest
+	knownPaths := make(map[string]bool)
+	for _, page := range m.Pages {
+		knownPaths[page.Path] = true
+	}
+
+	t.Logf("Checking links across %d pages...", len(m.Pages))
+
+	brokenLinks := 0
+	brokenAssets := 0
+
+	for _, page := range m.Pages {
+		// Skip non-HTML files (RSS feed)
+		if !strings.HasSuffix(page.File, ".html") && page.Path != "/feeds/rss" {
+			continue
+		}
+		if page.Path == "/feeds/rss" {
+			continue // RSS links checked separately
+		}
+
+		filePath := filepath.Join(outputDir, page.File)
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Errorf("reading %s: %v", page.File, err)
+			continue
+		}
+
+		hrefs, srcs := extractLinksFromHTML(string(content))
+
+		// Check internal links (hrefs)
+		for _, href := range hrefs {
+			// Strip fragment
+			if idx := strings.Index(href, "#"); idx != -1 {
+				href = href[:idx]
+			}
+			// Strip query string
+			if idx := strings.Index(href, "?"); idx != -1 {
+				href = href[:idx]
+			}
+			if href == "" || href == "/" {
+				continue
+			}
+
+			// Skip /Feeds/Rss (legacy casing in template, will be lowercased by CloudFront Function)
+			if strings.EqualFold(href, "/feeds/rss") {
+				continue
+			}
+
+			// Skip /content/images/* (legacy redirect handled by CloudFront Function)
+			if strings.HasPrefix(strings.ToLower(href), "/content/images/") {
+				continue
+			}
+
+			if !fileExistsInOutput(outputDir, href) {
+				brokenLinks++
+				if brokenLinks <= 20 {
+					t.Errorf("page %s: broken link %q - no file found in output", page.Path, href)
+				}
+			}
+		}
+
+		// Check internal sources (srcs)
+		for _, src := range srcs {
+			if !fileExistsInOutput(outputDir, src) {
+				brokenAssets++
+				if brokenAssets <= 20 {
+					t.Errorf("page %s: broken asset src %q - no file found in output", page.Path, src)
+				}
+			}
+		}
+	}
+
+	if brokenLinks > 20 || brokenAssets > 20 {
+		t.Errorf("too many broken links (%d) or assets (%d) to show all", brokenLinks, brokenAssets)
+	}
+
+	if brokenLinks == 0 && brokenAssets == 0 {
+		t.Log("All internal links and asset references are valid!")
+	}
+}
+
+func TestRSSLinksPointToGeneratedPages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping RSS link check in short mode")
+	}
+
+	root := repoRoot(t)
+	outputDir := generateStaticSite(t, root)
+
+	rssPath := filepath.Join(outputDir, "feeds", "rss")
+	rssData, err := os.ReadFile(rssPath)
+	if err != nil {
+		t.Fatalf("reading RSS: %v", err)
+	}
+
+	var feed rss
+	if err := xml.Unmarshal(rssData, &feed); err != nil {
+		t.Fatalf("parsing RSS XML: %v", err)
+	}
+
+	if len(feed.Channel.Items) == 0 {
+		t.Fatal("RSS feed has no items")
+	}
+
+	t.Logf("Checking %d RSS item links...", len(feed.Channel.Items))
+
+	for _, item := range feed.Channel.Items {
+		// RSS links are full URLs like https://www.tugberkugurlu.com/archive/slug
+		link := item.Link
+		if !strings.HasPrefix(link, "https://www.tugberkugurlu.com/") {
+			t.Errorf("RSS link does not start with expected prefix: %s", link)
+			continue
+		}
+
+		// Extract the path portion
+		urlPath := strings.TrimPrefix(link, "https://www.tugberkugurlu.com")
+
+		if !fileExistsInOutput(outputDir, urlPath) {
+			t.Errorf("RSS link %s does not correspond to a generated page", link)
+		}
+	}
+}
+
+func TestAllTagLinksResolve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping tag link resolution test in short mode")
+	}
+
+	root := repoRoot(t)
+	outputDir := generateStaticSite(t, root)
+
+	// Read the home page to find tag links in the sidebar
+	homePath := filepath.Join(outputDir, "index.html")
+	homeContent, err := os.ReadFile(homePath)
+	if err != nil {
+		t.Fatalf("reading home page: %v", err)
+	}
+
+	hrefs, _ := extractLinksFromHTML(string(homeContent))
+
+	tagLinks := 0
+	brokenTags := 0
+	for _, href := range hrefs {
+		if strings.HasPrefix(href, "/tags/") {
+			tagLinks++
+			if !fileExistsInOutput(outputDir, href) {
+				brokenTags++
+				t.Errorf("tag link %s does not resolve to a generated page", href)
+			}
+		}
+	}
+
+	if tagLinks == 0 {
+		t.Error("no tag links found in home page sidebar")
+	}
+
+	t.Logf("Checked %d tag links, %d broken", tagLinks, brokenTags)
+}
+
+func TestManifestPageFilesExist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping manifest file existence test in short mode")
+	}
+
+	root := repoRoot(t)
+	outputDir := generateStaticSite(t, root)
+
+	manifestData, err := os.ReadFile(filepath.Join(outputDir, "_manifest.json"))
+	if err != nil {
+		t.Fatalf("reading manifest: %v", err)
+	}
+
+	var m manifest
+	if err := json.Unmarshal(manifestData, &m); err != nil {
+		t.Fatalf("parsing manifest: %v", err)
+	}
+
+	for _, page := range m.Pages {
+		filePath := filepath.Join(outputDir, page.File)
+		info, err := os.Stat(filePath)
+		if os.IsNotExist(err) {
+			t.Errorf("manifest page %s references non-existent file %s", page.Path, page.File)
+			continue
+		}
+		if err != nil {
+			t.Errorf("stat %s: %v", page.File, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("manifest page %s: file %s is empty", page.Path, page.File)
+		}
+		if page.ContentHash == "" {
+			t.Errorf("manifest page %s has empty content hash", page.Path)
+		}
+	}
+
+	t.Logf("All %d manifest pages have valid files", len(m.Pages))
+}
+
+func TestOgUrlMetaTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping og:url meta tag test in short mode")
+	}
+
+	root := repoRoot(t)
+	outputDir := generateStaticSite(t, root)
+
+	// Check a sample of post pages for correct og:url
+	postDirs, err := os.ReadDir(filepath.Join(outputDir, "archive"))
+	if err != nil {
+		t.Fatalf("reading archive directory: %v", err)
+	}
+
+	checked := 0
+	for _, dir := range postDirs {
+		if !dir.IsDir() {
+			continue
+		}
+		indexPath := filepath.Join(outputDir, "archive", dir.Name(), "index.html")
+		content, err := os.ReadFile(indexPath)
+		if err != nil {
+			continue
+		}
+
+		htmlStr := string(content)
+		expectedOgUrl := fmt.Sprintf("https://www.tugberkugurlu.com/archive/%s", dir.Name())
+
+		if !strings.Contains(htmlStr, expectedOgUrl) {
+			// The post template sets og:url, so this should match
+			t.Errorf("post %s: og:url does not contain expected URL %s", dir.Name(), expectedOgUrl)
+		}
+
+		checked++
+		if checked >= 10 {
+			break // Spot-check 10 posts
+		}
+	}
+
+	t.Logf("Verified og:url for %d post pages", checked)
+}


### PR DESCRIPTION
## Summary

- Add side-by-side comparison test (`test/comparison/`) that runs both `cmd/generate` and `cmd/web`, then compares every page's HTML output byte-for-byte (after whitespace normalization)
- Add E2E link integrity test (`test/e2e/`) that validates all internal links and asset references in generated HTML resolve to actual files in the output
- Fix `TagCountPairList` sort to be deterministic by adding alphabetical tiebreaker when tags have equal counts

## Test details

**Side-by-side comparison** (`test/comparison/comparison_test.go`):
- Generates static site via `cmd/generate`
- Starts `cmd/web` on a dynamic port
- Compares all 356 HTML pages (357 minus RSS which has dynamic timestamps)
- Verifies all 22 redirect responses return correct 301 status and Location headers

**E2E link integrity** (`test/e2e/e2e_test.go`):
- Validates every internal `<a href="/...">` resolves to a generated file
- Validates every internal `<img src="/...">` resolves to a real asset
- Verifies all 20 RSS item links point to generated post pages
- Verifies all 183 tag links in the sidebar resolve to tag pages
- Checks all 357 manifest page files exist and are non-empty
- Spot-checks `og:url` meta tags on 10 post pages

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing tests + 6 new tests)
- [x] `go vet ./...` passes
- [x] Side-by-side: all 356 pages match between cmd/web and cmd/generate
- [x] Side-by-side: all 22 redirects verified
- [x] E2E: all internal links valid, all assets resolve, all RSS links valid

Co-Authored-By: Claude <noreply@anthropic.com>