### PR TITLE
Add docker-compose.dev.yml for local development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker-web.dockerfile
+    container_name: go-bloggy-dev
+    environment:
+      - SERVER_PORT=80
+    ports:
+      - "9847:80"
+    volumes:
+      # Mount posts and templates for live content changes without rebuilding
+      - ./web/posts:/go/src/app/web/posts:ro
+      - ./web/template:/go/src/app/web/template:ro
+      - ./web/static:/go/src/app/web/static:ro
+      - ./web/static-root:/go/src/app/web/static-root:ro
+      - ./config.yaml:/go/src/app/config.yaml:ro


### PR DESCRIPTION
## Summary

- Add `docker-compose.dev.yml` that runs `cmd/web` on port 9847
- Volume mounts for posts, templates, static assets, and config so content changes are reflected on container restart without image rebuild

## Usage

```bash
docker compose -f docker-compose.dev.yml up
# Visit http://localhost:9847
```

## Test plan

- [x] YAML is valid
- [x] Existing tests still pass (no code changes)

Co-Authored-By: Claude <noreply@anthropic.com>