### PR TITLE
Fix Deliveroo careers link on about page

### DIFF
--- a/web/template/about.html
+++ b/web/template/about.html
@@ -33,7 +33,7 @@
         </div>
         <div class="ui ten wide column">
             <p>
-                I'm a Senior Staff Software Engineer at <a href="https://careers.deliveroo.co.uk/pages/engineering">Deliveroo</a>,
+                I'm a Senior Staff Software Engineer at <a href="https://careers.deliveroo.co.uk/software-engineering-at-deliveroo/">Deliveroo</a>,
                 where I work on the architecture and evolution of consumer-facing platform systems.
             </p>
             <p>


### PR DESCRIPTION
## Summary
- Update the Deliveroo careers link on the about page from `https://careers.deliveroo.co.uk/pages/engineering` to `https://careers.deliveroo.co.uk/software-engineering-at-deliveroo/`

## Test plan
- [ ] Verify the link renders correctly on the about page
- [ ] Verify the new URL resolves to a valid page

🤖 Generated with [Claude Code](https://claude.com/claude-code)